### PR TITLE
Support Linux kernels 4.17+

### DIFF
--- a/ftrace_hook.c
+++ b/ftrace_hook.c
@@ -13,6 +13,7 @@
 #include <linux/module.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>
+#include <linux/version.h>
 
 MODULE_DESCRIPTION("Example module hooking clone() and execve() via ftrace");
 MODULE_AUTHOR("ilammy <a.lozovsky@gmail.com>");
@@ -257,9 +258,19 @@ static asmlinkage long fh_sys_execve(const char __user *filename,
 	return ret;
 }
 
+/*
+ * x86_64 kernels have a special naming convention for syscall entry points in newer kernels.
+ * That's what you end up with if an architecture has 3 (three) ABIs for system calls.
+ */
+#if defined(CONFIG_X86_64) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0))
+#define SYSCALL_NAME(name) ("__x64_" name)
+#else
+#define SYSCALL_NAME(name) (name)
+#endif
+
 #define HOOK(_name, _function, _original)	\
 	{					\
-		.name = (_name),		\
+		.name = SYSCALL_NAME(_name),	\
 		.function = (_function),	\
 		.original = (_original),	\
 	}


### PR DESCRIPTION
It turns out that Linux 4.17 has changed the naming convention of system call handlers for x86_64. Let's use the new names on those kernels.

See the ["x86 updates for 4.17" pull from Thomas Gleixner on 2018-04-15][1] for details on the in-kernel changes.

[1]: https://lkml.org/lkml/2018/4/15/115

Closes #2