### PR TITLE
Improved compatibility shims with kernel 5.11

### DIFF
--- a/ftrace_hook.c
+++ b/ftrace_hook.c
@@ -45,9 +45,12 @@ static unsigned long lookup_name(const char *name)
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-struct ftrace_regs {
-	struct pt_regs regs;
-};
+#define ftrace_regs pt_regs
+
+static __always_inline struct pt_regs *ftrace_get_regs(struct ftrace_regs *fregs)
+{
+	return fregs;
+}
 #endif
 
 /*
@@ -102,15 +105,16 @@ static int fh_resolve_hook_address(struct ftrace_hook *hook)
 }
 
 static void notrace fh_ftrace_thunk(unsigned long ip, unsigned long parent_ip,
-		struct ftrace_ops *ops, struct ftrace_regs *regs)
+		struct ftrace_ops *ops, struct ftrace_regs *fregs)
 {
+	struct pt_regs *regs = ftrace_get_regs(fregs);
 	struct ftrace_hook *hook = container_of(ops, struct ftrace_hook, ops);
 
 #if USE_FENTRY_OFFSET
-	regs->regs.ip = (unsigned long)hook->function;
+	regs->ip = (unsigned long)hook->function;
 #else
 	if (!within_module(parent_ip, THIS_MODULE))
-		regs->regs.ip = (unsigned long)hook->function;
+		regs->ip = (unsigned long)hook->function;
 #endif
 }
 


### PR DESCRIPTION
Following #9, make sure that the code still compiles—without warnings—for both newer 5.11 kernels as well as the previous ones.

Use preprocessor to keep the code *look* like it's for 5.11 while at the same time have the same function signature for older kernels to avoid causing compiler warnings.